### PR TITLE
Fix canonical Loki endpoint and rollout timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Componentes instalados:
 - `elven-mysql`, preparado como opcional para MySQL dentro do Kubernetes
 - `elven-beyla`, preparado como opcional e desligado por padrao
 
+Logs de backend e frontend usam TLS verificado no endpoint canonico
+`https://loki.elvenobservability.com`. O bootstrap migra automaticamente a
+Secret do collector-fe quando encontra o hostname legado
+`logs.elvenobservability.com`; desabilitar a verificacao TLS e proibido.
+
 ## Instalar
 
 Pre-requisitos locais:
@@ -48,10 +53,11 @@ Obrigatorias apenas quando a secret central ainda nao existe:
 Opcionais:
 
 - `ELVEN_NAMESPACE`, default `monitoring`
-- `COLLECTOR_FE_LOKI_URL`, default `https://logs.elvenobservability.com`
+- `COLLECTOR_FE_LOKI_URL`, default `https://loki.elvenobservability.com`
 - `COLLECTOR_FE_ALLOW_ORIGINS`, default `https://*.elvenobservability.com`
 - `COLLECTOR_FE_JWT_ISSUER`, default `elven-observability`
 - `COLLECTOR_FE_SECRET_KEY`, default gerado automaticamente e reaproveitado nas proximas execucoes
+- `ELVEN_ROLLOUT_TIMEOUT`, default `1800s`, para DaemonSets em clusters grandes
 - `INSTRUMENTATION_TARGET_NAMESPACES`, lista separada por virgula para limitar onde o `Instrumentation` sera aplicado
 
 Existe um exemplo em `bootstrap/env.example`.

--- a/apply-local-resources.sh
+++ b/apply-local-resources.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
+ROLLOUT_TIMEOUT="${ELVEN_ROLLOUT_TIMEOUT:-1800s}"
+[[ "${ROLLOUT_TIMEOUT}" =~ ^[1-9][0-9]*(s|m|h)$ ]] || {
+  printf 'Invalid ELVEN_ROLLOUT_TIMEOUT: %s\n' "${ROLLOUT_TIMEOUT}" >&2
+  exit 1
+}
 
 restart_if_present() {
   local resource="$1"
@@ -10,7 +15,8 @@ restart_if_present() {
 
   if kubectl get "${resource}" -n "${namespace}" >/dev/null 2>&1; then
     kubectl rollout restart "${resource}" -n "${namespace}"
-    kubectl rollout status "${resource}" -n "${namespace}" --timeout=300s
+    kubectl rollout status "${resource}" -n "${namespace}" \
+      --timeout="${ROLLOUT_TIMEOUT}"
   fi
 }
 

--- a/bootstrap/ensure-secrets.sh
+++ b/bootstrap/ensure-secrets.sh
@@ -9,6 +9,8 @@ cd "${REPO_DIR}"
 NAMESPACE="${ELVEN_NAMESPACE:-monitoring}"
 CREDENTIALS_SECRET="${ELVEN_CREDENTIALS_SECRET:-elven-observability-credentials}"
 COLLECTOR_FE_SECRET="${COLLECTOR_FE_SECRET_NAME:-elven-collector-fe-env-secret}"
+DEFAULT_COLLECTOR_FE_LOKI_URL="https://loki.elvenobservability.com"
+LEGACY_COLLECTOR_FE_LOKI_URL="https://logs.elvenobservability.com"
 
 log() {
   printf 'bootstrap: %s\n' "$*"
@@ -82,7 +84,15 @@ existing_allow_origins="$(secret_key_value_or_empty "${NAMESPACE}" "${COLLECTOR_
 existing_jwt_issuer="$(secret_key_value_or_empty "${NAMESPACE}" "${COLLECTOR_FE_SECRET}" JWT_ISSUER)"
 
 collector_fe_secret_key="${COLLECTOR_FE_SECRET_KEY:-${existing_secret_key:-$(generate_secret_key)}}"
-collector_fe_loki_url="${COLLECTOR_FE_LOKI_URL:-${existing_loki_url:-https://logs.elvenobservability.com}}"
+requested_loki_url="${COLLECTOR_FE_LOKI_URL:-${existing_loki_url}}"
+if [[ -z "${requested_loki_url}" || "${requested_loki_url}" == "${LEGACY_COLLECTOR_FE_LOKI_URL}" ]]; then
+  if [[ "${requested_loki_url}" == "${LEGACY_COLLECTOR_FE_LOKI_URL}" ]]; then
+    log "migrating collector-fe Loki endpoint from legacy logs host to loki.elvenobservability.com."
+  fi
+  collector_fe_loki_url="${DEFAULT_COLLECTOR_FE_LOKI_URL}"
+else
+  collector_fe_loki_url="${requested_loki_url}"
+fi
 collector_fe_allow_origins="${COLLECTOR_FE_ALLOW_ORIGINS:-${existing_allow_origins:-https://*.elvenobservability.com}}"
 collector_fe_jwt_issuer="${COLLECTOR_FE_JWT_ISSUER:-${existing_jwt_issuer:-elven-observability}}"
 

--- a/bootstrap/env.example
+++ b/bootstrap/env.example
@@ -4,9 +4,12 @@ export ELVEN_API_TOKEN="<SEU_API_TOKEN>"
 
 # Overrides opcionais.
 export ELVEN_NAMESPACE="monitoring"
-export COLLECTOR_FE_LOKI_URL="https://logs.elvenobservability.com"
+export COLLECTOR_FE_LOKI_URL="https://loki.elvenobservability.com"
 export COLLECTOR_FE_ALLOW_ORIGINS="https://*.elvenobservability.com"
 export COLLECTOR_FE_JWT_ISSUER="elven-observability"
+
+# Timeout por rollout. 1800s cobre DaemonSets em clusters com muitos nodes.
+export ELVEN_ROLLOUT_TIMEOUT="1800s"
 
 # Opcional: usado por ./elven-mysql/create-secret.sh quando habilitar a release elven-mysql.
 export ELVEN_MYSQL_PASSWORD="<MYSQL_EXPORTER_PASSWORD>"

--- a/bootstrap/prepare.sh
+++ b/bootstrap/prepare.sh
@@ -6,6 +6,7 @@ REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${REPO_DIR}"
 
+"${SCRIPT_DIR}/validate-endpoints.sh"
 "${SCRIPT_DIR}/preflight.sh"
 "${SCRIPT_DIR}/ensure-secrets.sh"
 "${REPO_DIR}/render-prometheus-values.sh"

--- a/bootstrap/validate-endpoints.sh
+++ b/bootstrap/validate-endpoints.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ALLOY_VALUES="${REPO_DIR}/elven-logs-collector/values-alloy.yaml"
+CANONICAL_PUSH_URL="https://loki.elvenobservability.com/loki/api/v1/push"
+
+grep -Fq "${CANONICAL_PUSH_URL}" "${ALLOY_VALUES}" || {
+  echo "bootstrap: Alloy must use ${CANONICAL_PUSH_URL}." >&2
+  exit 1
+}
+
+if grep -Fq 'logs.elvenobservability.com' "${ALLOY_VALUES}"; then
+  echo "bootstrap: Alloy still uses the legacy logs.elvenobservability.com host." >&2
+  exit 1
+fi
+
+if grep -Eq 'insecure_skip_verify[[:space:]]*=[[:space:]]*true' "${ALLOY_VALUES}"; then
+  echo "bootstrap: disabling Loki TLS verification is forbidden." >&2
+  exit 1
+fi
+
+echo "bootstrap: canonical Loki endpoint validation passed."

--- a/elven-logs-collector/values-alloy.yaml
+++ b/elven-logs-collector/values-alloy.yaml
@@ -48,7 +48,7 @@ logs:
   annotationFilter:
     enabled: false
   loki:
-    url: https://logs.elvenobservability.com/loki/api/v1/push
+    url: https://loki.elvenobservability.com/loki/api/v1/push
 
 alloy:
   stabilityLevel: generally-available

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -16,7 +16,7 @@ helmDefaults:
   waitForJobs: true
   atomic: true
   cleanupOnFail: true
-  timeout: 600
+  timeout: 1800
   historyMax: 10
 
 hooks:


### PR DESCRIPTION
## Summary
- route Alloy and collector-fe defaults through the canonical `loki.elvenobservability.com` endpoint
- migrate existing collector-fe Secrets that still contain the legacy `logs.elvenobservability.com` URL
- reject legacy Alloy endpoints and disabled TLS verification during bootstrap
- raise Helm and Kubernetes rollout timeouts to 1800s for larger EKS clusters

## Validation
- `bash -n`
- ShellCheck 0.11.0
- endpoint guard
- rendered `grafana/alloy` chart 1.8.2 contains the canonical push URL
- `helmfile build`
- `git diff --check`

The customer-specific WeHandle package has also passed a full three-node Kind migration and idempotency smoke test.